### PR TITLE
changed mixpanel url to use https

### DIFF
--- a/src/Mixpanel/Mixpanel/MixpanelClient.Http.cs
+++ b/src/Mixpanel/Mixpanel/MixpanelClient.Http.cs
@@ -9,7 +9,7 @@ namespace Mixpanel
 {
     public sealed partial class MixpanelClient
     {
-        internal const string UrlFormat = "http://api.mixpanel.com/{0}";
+        internal const string UrlFormat = "https://api.mixpanel.com/{0}";
         internal const string EndpointTrack = "track";
         internal const string EndpointEngage = "engage";
 


### PR DESCRIPTION
Please update url to use https, otherwise it does not work out of the box on iOS 9 and above.