### PR TITLE
Add duration Mixpanel property

### DIFF
--- a/src/Mixpanel/Mixpanel/MixpanelProperty.cs
+++ b/src/Mixpanel/Mixpanel/MixpanelProperty.cs
@@ -70,6 +70,11 @@
         /// </summary>
         public const string Alias = "alias";
 
+        /// <summary>
+        /// Duration for track messages.
+        /// </summary>
+        public const string Duration = "duration";
+
         internal const string TrackEvent = "event";
         internal const string TrackToken = "token";
         internal const string TrackDistinctId = "distinct_id";


### PR DESCRIPTION
Duration is a property for tracking how long an event took. It appears in the mixpanel interface as a mixpanel property. I don't believe it's used for Engage messages.