### PR TITLE
Handle "ID" in title case property names.

### DIFF
--- a/src/Mixpanel/Mixpanel.Tests/MessageProperties/PropertyNameFormatterTests.cs
+++ b/src/Mixpanel/Mixpanel.Tests/MessageProperties/PropertyNameFormatterTests.cs
@@ -88,7 +88,9 @@ namespace Mixpanel.Tests.MessageProperties
                 ("someCoolProperty", "Some Cool Property"),
                 ("prop", "Prop"),
                 ("PropP", "Prop P"),
-                ("Some Cool Property", "Some Cool Property"));
+                ("Some Cool Property", "Some Cool Property"),
+                ("DistinctID", "Distinct ID"),
+                ("DistinctId", "Distinct ID"));
         }
 
         #endregion TitleCase

--- a/src/Mixpanel/Mixpanel/MessageProperties/PropertyNameFormatter.cs
+++ b/src/Mixpanel/Mixpanel/MessageProperties/PropertyNameFormatter.cs
@@ -48,7 +48,11 @@ namespace Mixpanel.MessageProperties
                 if (char.IsUpper(letter))
                 {
                     // Do not add space if previous letter is space
-                    if (propertyName[i - 1] != ' ')
+                    // Or the current word is "ID" and we're in title case mode
+                    if (propertyName[i - 1] != ' '
+                        && !(titleCase
+                        && char.ToUpper(propertyName[i - 1]).Equals('I')
+                        && char.ToUpper(letter).Equals('D')))
                     {
                         newName.Append(' ');
                     }
@@ -58,6 +62,11 @@ namespace Mixpanel.MessageProperties
                         letter = char.ToLower(letter);
                     }
                 }
+                else if (titleCase && char.ToUpper(letter).Equals('D') && propertyName[i - 1].Equals('I'))
+                {
+                    letter = char.ToUpper(letter);
+                }
+
                 newName.Append(letter);
             }
 


### PR DESCRIPTION
Special-case the handling the of the abbreviation "ID"
in the property name formatter to match the convention used
by Mixpanel default properties (that is, upper-case).

This behavior is only enabled when the formatter is set to
title case.