### PR TITLE
Support Mixpanel's EU data residency

### DIFF
--- a/src/Mixpanel/Mixpanel.Tests/MixpanelClient/MixpanelClientHttpTests.cs
+++ b/src/Mixpanel/Mixpanel.Tests/MixpanelClient/MixpanelClientHttpTests.cs
@@ -88,6 +88,31 @@ namespace Mixpanel.Tests.MixpanelClient
             AssertAllUrls(url => Assert.That(url, Does.Contain(Ip0Param)));
         }
 
+        [Test]
+        public void Given_CallingAllMethods_When_DefaultConfig_Then_UseDefaultHost()
+        {
+            CallAllMixpanelMethods();
+            AssertAllUrls(url => Assert.That(url, Does.StartWith("https://api.mixpanel.com")));
+        }
+
+        [Test]
+        public void Given_CallingAllMethods_When_ConfigUseDefaultDataResidency_Then_UseDefaultHost()
+        {
+            MixpanelConfig.Global.DataResidencyHandling = MixpanelDataResidencyHandling.Default;
+
+            CallAllMixpanelMethods();
+            AssertAllUrls(url => Assert.That(url, Does.StartWith("https://api.mixpanel.com")));
+        }
+
+        [Test]
+        public void Given_CallingAllMethods_When_ConfigUseEUDataResidency_Then_UseEUHost()
+        {
+            MixpanelConfig.Global.DataResidencyHandling = MixpanelDataResidencyHandling.EU;
+
+            CallAllMixpanelMethods();
+            AssertAllUrls(url => Assert.That(url, Does.StartWith("https://api-eu.mixpanel.com")));
+        }
+
         private void CallAllMixpanelMethods()
         {
             foreach (Action mixpanelMethod in mixpanelMethods)

--- a/src/Mixpanel/Mixpanel.Tests/MixpanelClient/MixpanelClientTestsBase.cs
+++ b/src/Mixpanel/Mixpanel.Tests/MixpanelClient/MixpanelClientTestsBase.cs
@@ -16,11 +16,9 @@ namespace Mixpanel.Tests.MixpanelClient
 
         protected List<(string Endpoint, string Data)> HttpPostEntries;
 
-        protected string TrackUrl =>
-            string.Format(Mixpanel.MixpanelClient.UrlFormat, Mixpanel.MixpanelClient.EndpointTrack);
+        protected string TrackUrl { get; set; }
 
-        protected string EngageUrl =>
-            string.Format(Mixpanel.MixpanelClient.UrlFormat, Mixpanel.MixpanelClient.EndpointEngage);
+        protected string EngageUrl { get; set; }
 
         [SetUp]
         public void MixpanelClientSetUp()
@@ -30,6 +28,9 @@ namespace Mixpanel.Tests.MixpanelClient
             Client = new Mixpanel.MixpanelClient(Token, GetConfig());
 
             HttpPostEntries = new List<(string Endpoint, string Data)>();
+
+            TrackUrl = string.Format(Client.GetUrlFormat(), Mixpanel.MixpanelClient.EndpointTrack);
+            EngageUrl = string.Format(Client.GetUrlFormat(), Mixpanel.MixpanelClient.EndpointEngage);
         }
 
         protected static void IncludeDistinctIdIfNeeded(bool includeDistinctId, Dictionary<string, object> dic)

--- a/src/Mixpanel/Mixpanel/ConfigHelper.cs
+++ b/src/Mixpanel/Mixpanel/ConfigHelper.cs
@@ -79,5 +79,20 @@ namespace Mixpanel
 
             return MixpanelIpAddressHandling.None;
         }
+
+        public static MixpanelDataResidencyHandling GetDataResidencyHandling(MixpanelConfig config)
+        {
+            if (config != null && config.DataResidencyHandling != null)
+            {
+                return config.DataResidencyHandling.Value;
+            }
+
+            if (MixpanelConfig.Global.DataResidencyHandling != null)
+            {
+                return MixpanelConfig.Global.DataResidencyHandling.Value;
+            }
+
+            return MixpanelDataResidencyHandling.Default;
+        }
     }
 }

--- a/src/Mixpanel/Mixpanel/MixpanelClient.Http.cs
+++ b/src/Mixpanel/Mixpanel/MixpanelClient.Http.cs
@@ -8,7 +8,6 @@ namespace Mixpanel
 {
     public sealed partial class MixpanelClient
     {
-        internal const string UrlFormat = "https://api.mixpanel.com/{0}";
         internal const string EndpointTrack = "track";
         internal const string EndpointEngage = "engage";
 
@@ -25,9 +24,22 @@ namespace Mixpanel
             }
         }
 
+        internal string GetUrlFormat()
+        {
+            MixpanelDataResidencyHandling dataResidencyHandling = ConfigHelper.GetDataResidencyHandling(config);
+
+            switch (dataResidencyHandling)
+            {
+                case MixpanelDataResidencyHandling.EU:
+                    return "https://api-eu.mixpanel.com/{0}";
+                default:
+                    return "https://api.mixpanel.com/{0}";
+            }
+        }
+
         private string GenerateUrl(MixpanelMessageEndpoint endpoint)
         {
-            string url = string.Format(UrlFormat, GetEndpoint(endpoint));
+            string url = string.Format(GetUrlFormat(), GetEndpoint(endpoint));
 
             MixpanelIpAddressHandling ipAddressHandling = ConfigHelper.GetIpAddressHandling(config);
             switch (ipAddressHandling)

--- a/src/Mixpanel/Mixpanel/MixpanelConfig.cs
+++ b/src/Mixpanel/Mixpanel/MixpanelConfig.cs
@@ -45,6 +45,11 @@ namespace Mixpanel
         public MixpanelIpAddressHandling? IpAddressHandling { get; set; }
 
         /// <summary>
+        /// Regulates which API host to route data to.
+        /// </summary>
+        public MixpanelDataResidencyHandling? DataResidencyHandling { get; set; }
+
+        /// <summary>
         /// A global instance of the config.
         /// </summary>
         public static MixpanelConfig Global { get; }
@@ -65,6 +70,7 @@ namespace Mixpanel
             ErrorLogFn = null;
             MixpanelPropertyNameFormat = null;
             IpAddressHandling = null;
+            DataResidencyHandling = null;
         }
     }
 }

--- a/src/Mixpanel/Mixpanel/MixpanelDataResidencyHandling.cs
+++ b/src/Mixpanel/Mixpanel/MixpanelDataResidencyHandling.cs
@@ -1,0 +1,18 @@
+﻿namespace Mixpanel
+{
+    /// <summary>
+    /// Controls which API host to route data to.
+    /// </summary>
+    public enum MixpanelDataResidencyHandling
+    {
+        /// <summary>
+        /// Route data to Mixpanel's US servers.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Route data to Mixpanel's EU servers.
+        /// </summary>
+        EU,
+    }
+}


### PR DESCRIPTION
Mixpanels has support for [EU data residency](https://help.mixpanel.com/hc/en-us/articles/360039135652-Data-Residency-in-EU) via a new endpoint `https://api-eu.mixpanel.com`.

This PR adds a configuration option to use that endpoint.
I've created it very similar to how IP Address Handling is created.

```c#
new MixpanelClient("xxx", new MixpanelConfig
{
     DataResidencyHandling = MixpanelDataResidencyHandling.EU
});

// or
MixpanelConfig.Global.DataResidencyHandling = MixpanelDataResidencyHandling.EU;
MixpanelConfig.Global.DataResidencyHandling = MixpanelDataResidencyHandling.Default;
```