### PR TITLE
Added the possibility to have custom parsers

### DIFF
--- a/src/Mixpanel/Mixpanel/MessageBuilders/Track/TrackMessageBuilder.cs
+++ b/src/Mixpanel/Mixpanel/MessageBuilders/Track/TrackMessageBuilder.cs
@@ -71,7 +71,17 @@ namespace Mixpanel.MessageBuilders.Track
                 string formattedPropertyName = pair.Key;
                 ObjectProperty objectProperty = pair.Value;
 
-                ValueParseResult result = GenericPropertyParser.Parse(objectProperty.Value, allowCollections: true);
+                ValueParseResult result;
+
+                if (config.CustomPropertiesParser != null)
+                {
+                    result = config.CustomPropertiesParser(objectProperty.Value, true);
+                }
+                else
+                {
+                    result = GenericPropertyParser.Parse(objectProperty.Value, allowCollections: true);
+                }
+
                 if (!result.Success)
                 {
                     continue;

--- a/src/Mixpanel/Mixpanel/MixpanelConfig.cs
+++ b/src/Mixpanel/Mixpanel/MixpanelConfig.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Mixpanel.Parsers;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -48,6 +49,11 @@ namespace Mixpanel
         /// A global instance of the config.
         /// </summary>
         public static MixpanelConfig Global { get; }
+
+        /// <summary>
+        /// With this property you can create your own Parser to handle custom properties.
+        /// </summary>
+        public Func<object, bool, ValueParseResult> CustomPropertiesParser { get; set; }
 
         static MixpanelConfig()
         {

--- a/src/Mixpanel/Mixpanel/Parsers/ValueParseResult.cs
+++ b/src/Mixpanel/Mixpanel/Parsers/ValueParseResult.cs
@@ -1,6 +1,6 @@
 ﻿namespace Mixpanel.Parsers
 {
-    internal sealed class ValueParseResult
+    public sealed class ValueParseResult
     {
         public bool Success { get; }
         public object Value { get; }


### PR DESCRIPTION
When creating track messages a parser is used by this package that can only handle a **very** limited number of property types. We at AFAS want to use a more complex parser to send our messages. I saw an issue where someone else also wants to have this.

I would recommend to implement this in this way so that this package stays simple and generic, and for the more advanced users we can create our own (specialised) parsers.